### PR TITLE
Changed name of PAT token in scheduled playwright workflow

### DIFF
--- a/.github/workflows/playwright-scheduled.yml
+++ b/.github/workflows/playwright-scheduled.yml
@@ -56,7 +56,7 @@ jobs:
       with:
         external_repository: mspnp/intern-js-pipeline
         publish_branch: gh-pages
-        personal_token: ${{ secrets.PERSONAL_TOKEN }}
+        personal_token: ${{ secrets.PAT_TOKEN }}
         publish_dir: ${{steps.download.outputs.download-path}}
         destination_dir: test-reports/${{ github.repository }}
         keep_files: true


### PR DESCRIPTION
Changed the name of the PAT token used in the playwright-scheduled.yml workflow from PERSONAL_TOKEN (which didn't exist) to PAT_TOKEN. Originally the PERSONAL_TOKEN was causing the scheduled tests to fail but this should fix them