### PR TITLE
Added Visual Studio Code extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "ms-azuretools.vscode-azurestaticwebapps", 
+    "ms-vscode-remote.remote-containers"
+  ]
+}

--- a/readme.md
+++ b/readme.md
@@ -4,4 +4,4 @@
 
 This repo is used as a starter for a _very basic_ HTML web application using no front-end frameworks.
 
-This repo has a dev container. This means if you open it inside a [GitHub Codespace](https://github.com/features/codespaces), or using [VS Code with the remote containers extension](https://code.visualstudio.com/docs/remote/containers), it will be opened inside a container with all the dependencies already installed.
+This repo has a dev container. This means if you open it inside a [GitHub Codespace](https://github.com/features/codespaces), or using [VS Code with the Dev Containers extension](https://code.visualstudio.com/docs/remote/containers), it will be opened inside a container with all the dependencies already installed.


### PR DESCRIPTION
Resolves #25 

The /readme.md mentions the remote containers extension (which does not exist in the marketplace by that name). When following the link it actually mentions the Dev Containers extensions on the first line. 
On opening the repo, Visual Studio code detects and recommends that Dev Containers extension (which does exist)
The quickstart guide linked in the repo's About recommends the Azure Static Web Apps extension as well. 

- Both recommended extensions have been added to a /.vscode/extensions.json to have Visual Studio Code notify developers of these recommendations on repo open. 
- Corrected the link name for the Dev Containers extension.